### PR TITLE
prevent alt account

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,17 @@ vulnerabilities.
 
 ## Exploits
 
+### Prevent alternative account
+
+Enabling this feature will block accounts that do not go through Mojang's certificateserver when connecting to the server.
+For example: EasyMC, Thealtening
+Caution: May be restricted on servers that have reverse proxy configured.
+
+`server.properties`
+```properties
+prevent-proxy-connections=true
+```
+
 ### Armor stand lag machines
 
 Armor stands can be used to create lag machines. This is done by placing huge amounts of armor stands and forcing them


### PR DESCRIPTION
When connecting to the server, if the endpoint does not match Mojang's certificate server, access will be denied.