### PR TITLE
Add EXPERIENCE_BOTTLE to entity timeout

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -149,6 +149,7 @@ entity_timeouts:
   ARROW: 200
   EGG: 200
   ENDER_PEARL: 200
+  EXPERIENCE_BOTTLE: 200
   SNOWBALL: 200
 ```
 


### PR DESCRIPTION
Users often use experience bottles via dispenser through the same methods as snowballs to cause lag on your server.